### PR TITLE
minor hashtag mismatch replaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ That's it! You have successfully forked a repository and hosted an HTML file usi
 
 ### Sample Message
 
-#ge-learn-ghpages
+#ge-github-pages
 
 Hey, I have completed the Learn Github Pages task, and here is the hosted link to my task.
 Hosted Link: `https://yourusername.github.io/forked-repo-name/`

--- a/index.html
+++ b/index.html
@@ -94,8 +94,7 @@
                                     <div class="col-md-6">
                                         <div class="detail-box">
                                             <h1>
-                                                Github<br />
-                                                Pages
+                                                Github Page by Muzammil Ibrahim
                                             </h1>
                                             <p>
                                                 Hosting your first GitHub web


### PR DESCRIPTION
In the Readme.md file, The hashtag for Task 4: HTML File on GitHub is #ge-github-pages. 
Previously it was: ```#ge-learn-ghpages```
Replaced with: ```#ge-github-pages```